### PR TITLE
Fix bug, XHR request fails if the URL is not ending with a '/'

### DIFF
--- a/lib/es/widgets.js
+++ b/lib/es/widgets.js
@@ -1169,6 +1169,10 @@
 		init: function(parent) {
 			this._super();
 			this.base_uri = localStorage["base_uri"] || this.config.base_uri;
+			if (this.base_uri.charAt(this.base_uri.length-1) != "/") {
+			    // XHR request fails if the URL is not ending with a "/"
+			    this.base_uri += "/";
+			}
 			this.cluster = new es.Cluster({ base_uri: this.base_uri });
 			this._initElements(parent);
 		},


### PR DESCRIPTION
Small fix but very useful for me and I think I'm not the only one to type the URL without the ending slash which makes the XHR request fail. Result : blank page because it was cleared then crash.
