### PR TITLE
base_uri parameter should override last cluster address from local storage

### DIFF
--- a/lib/es/widgets.js
+++ b/lib/es/widgets.js
@@ -1245,11 +1245,11 @@
 
 	es.ElasticSearchHead = acx.ui.Widget.extend({
 		defaults: {
-			base_uri: "http://localhost:9200/"   // the default ElasticSearch host
+			base_uri: localStorage["base_uri"] || "http://localhost:9200/"   // the default ElasticSearch host
 		},
 		init: function(parent) {
 			this._super();
-			this.base_uri = localStorage["base_uri"] || this.config.base_uri;
+			this.base_uri = this.config.base_uri;
 			if (this.base_uri.charAt(this.base_uri.length-1) != "/") {
 			    // XHR request fails if the URL is not ending with a "/"
 			    this.base_uri += "/";


### PR DESCRIPTION
This patch makes the base_uri query string value override the last cluster name from local storage. This patch allows my monitoring console site to construct links to elasticsearch-head views of any cluster, regardless of which cluster I last connected to.

Thanks!
