### PR TITLE
Allow query separation. Useful for complex queries. 

### DIFF
--- a/lib/es/widgets.js
+++ b/lib/es/widgets.js
@@ -420,11 +420,12 @@
 			this.transformEl.val(item.transform);
 		},
 		_request_handler: function(jEv) {
-			if(! this._validateJson_handler()) return;
+			//if(! this._validateJson_handler()) return;
 
 			var path = this.pathEl.val(),
 					type = this.typeEl.val(),
-					query = JSON.stringify(JSON.parse(this.dataEl.val())),
+					//query = JSON.stringify(JSON.parse(this.dataEl.val())),
+                                        query = JSON.stringify(eval(this.dataEl.val())),            					                                        
 					transform = this.transformEl.val(),
 					base_uri = this.base_uriEl.val();
 			if(jEv && jEv.originalEvent) { // if the user click request


### PR DESCRIPTION
I know that this patch is not complete (probably it is not even useful) but I want to document it somewhere:

I want to be able to split my query via javascript in the "Any Request" Tab. Just to avoid bracket confusion of complex queries. The only problem now for me is that I need to use round brackets around every json:

q=({match_all:{}});
({query:q})

Anyone knows a workaround for this?
