### PR TITLE
index.status.docs may be missing if the index is recovering

### DIFF
--- a/lib/es/widgets.js
+++ b/lib/es/widgets.js
@@ -935,7 +935,7 @@
 		_indexHeader_template: function(index) {
 			var closed = index.state === "close";
 			var line1 = closed ? "index: close" : ( "size: " + (index.status && index.status.index ? index.status.index.primary_size + " (" + index.status.index.size + ")" : "unknown" ) ); 
-			var line2 = closed ? "\u00A0" : ( "docs: " + (index.status ? index.status.docs.num_docs + " (" + index.status.docs.max_doc + ")" : "unknown" ) );
+			var line2 = closed ? "\u00A0" : ( "docs: " + (index.status && index.status.docs ? index.status.docs.num_docs + " (" + index.status.docs.max_doc + ")" : "unknown" ) );
 			return index.name ? { tag: "TH", cls: (closed ? "close" : ""), children: [
 				{ tag: "DIV", cls: "clusterOverview-title", text: index.name },
 				{ tag: "DIV", text: line1 },


### PR DESCRIPTION
I couldn't access elasticsearch-head on a recovering cluster since index.status.docs was missing during the recovery. Simple checking whether it exists before accessing it seems to be the quick and correct way of fixing this issue :)
