### PR TITLE
Mention in the docs that you need to run as sudo to install

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -12,7 +12,7 @@ h4. Running as a plugin of ElasticSearch (this is the preferred method)
 
 If you've installed the .deb package, then the plugin exectuable will be available at /usr/share/elasticsearch/bin/plugin.
 
-* @elasticsearch/bin/plugin -install mobz/elasticsearch-head@
+* @sudo elasticsearch/bin/plugin -install mobz/elasticsearch-head@
 * @open http://localhost:9200/_plugin/head/@
 
 This will automatically download the latest version of elasticsearch-head from github and run it as a plugin within the elasticsearch cluster. In this mode;


### PR DESCRIPTION
Without sudo I got the following error:

$ /usr/share/elasticsearch/bin/plugin -install mobz/elasticsearch-head
-> Installing mobz/elasticsearch-head...
Trying https://github.com/downloads/mobz/elasticsearch-head/elasticsearch-head-0.19.1.zip...
Trying https://github.com/mobz/elasticsearch-head/zipball/v0.19.1...
Trying https://github.com/mobz/elasticsearch-head/zipball/master...
Failed to install mobz/elasticsearch-head, reason: failed to download
