### PR TITLE
add additional numeric types to be recognized

### DIFF
--- a/lib/es/widgets.js
+++ b/lib/es/widgets.js
@@ -1588,7 +1588,8 @@
 				ops = ["query_string"];
 			} else if(spec.type === 'string') {
 				ops = ["term", "wildcard", "prefix", "fuzzy", "range", "query_string"];
-			} else if(spec.type === 'long') {
+			} else if(spec.type === 'long' || spec.type === 'integer' || spec.type === 'float' ||
+					spec.type === 'byte' || spec.type == 'short' || spec.type == 'double') {
 				ops = ["term", "range", "fuzzy", "query_string"];
 			} else if(spec.type === 'date') {
 				ops = ["term", "range", "fuzzy", "query_string"];


### PR DESCRIPTION
Some numeric types were missing and so selecting a field in the query builder of such a type would result in a blank query type selection dropdown.  Added: integer, float, byte, short, double.

Note: this does not address any other missing types and their available query types. 
