### PR TITLE
Show parent fields in browser view

### DIFF
--- a/lib/es/core.js
+++ b/lib/es/core.js
@@ -145,7 +145,7 @@
 				})(properties, []);
 			}
 			for(var index in state.metadata.indices) {
-				indices[index] = { types: [], fields: {}, paths: {} };
+				indices[index] = { types: [], fields: {}, paths: {}, parents: {} };
 				indices[index].aliases = state.metadata.indices[index].aliases;
 				indices[index].aliases.forEach(function(alias) {
 					( aliases[alias] || (aliases[alias] = [ ])).push(index);
@@ -159,6 +159,9 @@
 						types[type] = { indices: [ index ], fields: {} };
 					}
 					getFields(mapping[type].properties, type, index, [ fields, types[type].fields, indices[index].fields ]);
+          if (typeof mapping[type]._parent != "undefined"){
+            indices[index].parents[type] = mapping[type]._parent.type;
+          }
 				}
 			}
 			this.aliasesList = Object.keys(aliases);
@@ -194,7 +197,8 @@
 			this.indices = [];
 			this.types = [];
 			this.search = {
-				query: { bool: { must: [], must_not: [], should: [] } },
+				fields : [ "_parent", "_source" ],
+        query: { bool: { must: [], must_not: [], should: [] } },
 				from: 0,
 				size: this.config.size,
 				sort: [],
@@ -236,9 +240,66 @@
 							return;
 						}
 						this.history.push(state);
+
 						this.fire("results", this, results);
 					}.bind(this));
 		},
+    loadParents: function(res,metadata){
+      //create data for mget
+      var data = { docs :[] };
+      var indexToTypeToParentIds = new Object();
+      res.hits.hits.forEach(function(hit) {
+        if (typeof hit.fields != "undefined"){
+          if (typeof hit.fields._parent != "undefined"){
+            var parentType = metadata.indices[hit._index].parents[hit._type];
+            if (typeof indexToTypeToParentIds[hit._index] == "undefined"){
+                indexToTypeToParentIds[hit._index] = new Object();
+             }
+             if (typeof indexToTypeToParentIds[hit._index][hit._type] == "undefined"){
+                indexToTypeToParentIds[hit._index][hit._type] = new Object();
+             }
+             if (typeof indexToTypeToParentIds[hit._index][hit._type][hit.fields._parent] == "undefined"){
+                indexToTypeToParentIds[hit._index][hit._type][hit.fields._parent] = null;
+                data.docs.push({ _index:hit._index, _type:parentType, _id:hit.fields._parent});
+             }
+          }
+        }
+      });
+
+      //load parents
+      var state = this.getState();
+			this.cluster.post("_mget",JSON.stringify(data),
+					function(results) {
+						if(results === null) {
+							alert("Query Failed. Undoing last changes");
+							this.restoreState();
+							return;
+						}
+						this.history.push(state);
+            var indexToTypeToParentIdToHit = new Object();
+            results.docs.forEach(function(doc) {
+              if (typeof indexToTypeToParentIdToHit[doc._index] == "undefined"){
+                indexToTypeToParentIdToHit[doc._index] = new Object();
+              }
+
+              if (typeof indexToTypeToParentIdToHit[doc._index][doc._type] == "undefined"){
+                indexToTypeToParentIdToHit[doc._index][doc._type] = new Object();
+              }
+              indexToTypeToParentIdToHit[doc._index][doc._type][doc._id] = doc;
+            });
+
+            res.hits.hits.forEach(function(hit) {
+              if (typeof hit.fields != "undefined"){
+                if (typeof hit.fields._parent != "undefined"){
+                  var parentType = metadata.indices[hit._index].parents[hit._type];
+                  hit._parent = indexToTypeToParentIdToHit[hit._index][parentType][hit.fields._parent];
+                }
+              }
+            });
+
+						this.fire("resultsWithParents", this, res);
+					}.bind(this));
+    },
 		setPage: function(page) {
 			this.search.from = this.config.size * (page - 1);
 		},
@@ -365,7 +426,8 @@
 		},
 		init: function() {
 			this._super();
-			this.config.query.on("results", this._results_handler.bind(this));
+			this.config.query.on("results", this._load_parents.bind(this));
+      this.config.query.on("resultsWithParents", this._results_handler.bind(this));
 		},
 		_results_handler: function(query, res) {
 			this._getSummary(res);
@@ -376,10 +438,14 @@
 			this._getData(res, this.config.metadata);
 			this.fire("data", this);
 		},
+    _load_parents: function(query, res) {
+			query.loadParents(res, this.config.metadata);
+		},
 		_getData: function(res, metadata) {
 			var metaColumns = ["_index", "_type", "_id", "_score"];
 			var columns = this.columns = [].concat(metaColumns);
-			this.data = res.hits.hits.map(function(hit) {
+
+      this.data = res.hits.hits.map(function(hit) {
 				var row = (function(path, spec, row) {
 					for(var prop in spec) {
 						if(acx.isObject(spec[prop])) {
@@ -405,7 +471,33 @@
 				})([ hit._index, hit._type ], hit._source, {});
 				metaColumns.forEach(function(n) { row[n] = hit[n]; });
 				row._source = hit;
-				return row;
+        //row._parent = "";
+        if (typeof hit._parent!= "undefined"){
+          (function(prefix, path, spec, row) {
+					for(var prop in spec) {
+						if(acx.isObject(spec[prop])) {
+							arguments.callee(prefix, path.concat(prop), spec[prop], row);
+						} else if(acx.isArray(spec[prop])) {
+							if(spec[prop].length) {
+								arguments.callee(prefix, path.concat(prop), spec[prop][0], row)
+							}
+						} else{
+							var dpath = path.concat(prop).join(".");
+							if(metadata.paths[dpath]) {
+								var field_name = metadata.paths[dpath].field_name;
+                var column_name = prefix+"."+field_name;
+								if(! columns.contains(column_name)) {
+									columns.push(column_name);
+								}
+								row[column_name] = (spec[prop] === null ? "null" : spec[prop] ).toString();
+							} else {
+								// TODO: field not in metadata index
+							}
+						}
+					}
+				  })(hit._parent._type,[hit._parent._index, hit._parent._type], hit._parent._source, row);
+        }
+        return row;
 			}, this);
 		}
 	});


### PR DESCRIPTION
Hi,

I implemented "_parent" support for browser view. If a type has parent, then the source fields of parent are displayed in the browser table.

It would be good if you integrate it to trunk.

PS:
I will try also to implement some possibility to define the columns which shall be displayed in the browser table. In order to hid e.g some columns. I want to store he definition in _meta of type. 

Like "_meta" : {
            "elasticsearch-head" : {
                 "columns" : "_id, _score, ...",
                 "show-parent" : "true",
                 ....
            }
        }

What do you think?
