### PR TITLE
added extra security to the deletion of aliases & style changes to aliases

### DIFF
--- a/lib/es/es.css
+++ b/lib/es/es.css
@@ -437,6 +437,8 @@ SPAN.jsonPretty-boolean { color: purple; }
 }
 .clusterOverview-hasAlias {
 	text-align: center;
+	padding: 2px 20px;
+	margin-bottom: 5px;
 }
 .clusterOverview-hasAlias.max {
 	-webkit-border-top-right-radius: 8px;

--- a/lib/es/widgets.js
+++ b/lib/es/widgets.js
@@ -856,6 +856,19 @@
 				}.bind(this) );
 			}
 		},
+		_deleteAliasAction_handler: function(index, alias) {
+			if(prompt("type 'DELETE' to delete the alias " + alias + ". There is no undo") === "DELETE") {
+				var command = {
+					"actions" : [
+						{ "remove" : { "index" : index.name, "alias" : alias } }
+					]
+				};
+				this.config.cluster.post('_aliases', JSON.stringify(command), function(d) {
+					alert(JSON.stringify(d));
+					this.redraw("reset");
+				}.bind(this) );
+			}
+		},
 		_postIndexAction_handler: function(action, index, redraw) {
 			this.cluster.post(index.name + "/" + action, null, function(r) {
 				alert(JSON.stringify(r));
@@ -938,6 +951,24 @@
 			var line2 = closed ? "\u00A0" : ( "docs: " + (index.status && index.status.docs ? index.status.docs.num_docs + " (" + index.status.docs.max_doc + ")" : "unknown" ) );
 			return index.name ? { tag: "TH", cls: (closed ? "close" : ""), children: [
 				{ tag: "DIV", cls: "clusterOverview-title", text: index.name },
+				{ tag: "DIV", children: [].concat(index.metadata.aliases.map(function(alias, a) {
+						return {
+							tag: "DIV",
+							css: { background: "#" + "9ce9c7fc9".substr((a+6)%7,3) },
+							cls: "clusterOverview-hasAlias min max",
+							text: alias,
+							children: [
+								{	tag: 'SPAN',
+									text: 'X',
+									cls: 'clusterOverview-hasAlias-remove',
+									onclick: function() {
+										this._deleteAliasAction_handler(index, alias);
+									}.bind(this)
+								}
+							]
+						};
+					}, this)
+				)},
 				{ tag: "DIV", text: line1 },
 				{ tag: "DIV", text: line2 },
 				{ tag: "DIV", children: [
@@ -967,43 +998,9 @@
 				] }
 			]} : { tag: "TH" };
 		},
-		_alias_template: function(alias, row) {
-			return { tag: "TR", children: [ { tag: "TD"	} ].concat(alias.indices.map(function(index, i) {
-				if (index) {
-					return {
-						tag: "TD",
-						css: { background: "#" + "9ce9c7fc9".substr((row+6)%7,3) },
-						cls: "clusterOverview-hasAlias" + ( alias.min == i ? " min" : "" ) + ( alias.max == i ? " max" : "" ),
-						text: alias.name,
-						children: [
-							{	tag: 'SPAN',
-								text: 'X',
-								cls: 'clusterOverview-hasAlias-remove',
-								onclick: function() {
-									var command = {
-										"actions" : [
-											{ "remove" : { "index" : index.name, "alias" : alias.name } }
-										]
-									};
-									this.config.cluster.post('_aliases', JSON.stringify(command), function(d) {
-										alert(JSON.stringify(d));
-										this.redraw("reset");
-									}.bind(this) );
-								}.bind(this)
-							}
-						]
-					};
-				}
-				else {
-					return { tag: "TD" };
-				}
-			},
-			this)) };
-		},
 		_cluster_template: function(cluster, indices) {
 			return { tag: "TABLE", cls: "clusterOverview-cluster", children: [
 				{ tag: "THEAD", child: { tag: "TR", children: indices.map(this._indexHeader_template, this) } },
-				cluster.aliases.length && { tag: "TBODY", children: cluster.aliases.map(this._alias_template, this) },
 				{ tag: "TBODY", children: cluster.nodes.map(this._node_template, this) }
 			] };
 		},


### PR DESCRIPTION
Deleting an alias now requires a user to type in the DELETE command, similar to the deleting of indexes for extra security so that aliases aren't deleted accidentally.

I also changed the styling of the aliases to display directly below the index name and to not take an entire table row per alias.  If the previous location of the aliases (directly below the info and action dropdowns) is the preferred location for aliases, I also have local changes I can push that restyle them their so that they still can have aliases for different indexes in the same table row.
