### PR TITLE
Add proxy support

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
 				var args = location.search.substring(1).split("&").reduce(function(r, p) {
 					r[decodeURIComponent(p.split("=")[0])] = decodeURIComponent(p.split("=")[1]); return r;
 				}, {});
-				new es.ElasticSearchHead("body", { id: "es", base_uri: args["base_uri"] || base_uri });
+				new es.ElasticSearchHead("body", { id: "es", base_uri: args["base_uri"] || base_uri, proxy: false });
 			});
 		</script>
 		<link rel="icon" href="lib/es/images/favicon.png" type="image/png">

--- a/lib/es/core.js
+++ b/lib/es/core.js
@@ -75,8 +75,12 @@
 			base_uri: "http://localhost:9200/"
 		},
 		request: function(params) {
+			var url = this.config.base_uri + params.path;
+			if (this.config.proxy) {
+				url = this.config.proxy + '?uri=' + encodeURI(url);
+			}
 			return $.ajax(acx.extend({
-				url: this.config.base_uri + params.path,
+				url: url,
 				dataType: "json",
 				error: function(xhr, type, message) {
 					if("console" in window) {

--- a/lib/es/widgets.js
+++ b/lib/es/widgets.js
@@ -1280,7 +1280,7 @@
 			    // XHR request fails if the URL is not ending with a "/"
 			    this.base_uri += "/";
 			}
-			this.cluster = new es.Cluster({ base_uri: this.base_uri });
+			this.cluster = new es.Cluster({ base_uri: this.base_uri, proxy: this.config.proxy });
 			this._initElements(parent);
 			this.instances = {};
 			this.quicks = {};
@@ -1324,7 +1324,7 @@
 			return { tag: "DIV", cls: "es", children: [
 				{ tag: "DIV", id: this.id("header"), cls: "es-header", children: [
 					{ tag: "DIV", cls: "es-header-top", children: [
-						new es.ClusterConnect({ base_uri: this.base_uri, onStatus: this._status_handler, onReconnect: this._reconnect_handler }),
+						new es.ClusterConnect({ base_uri: this.base_uri, onStatus: this._status_handler, onReconnect: this._reconnect_handler, proxy: this.config.proxy }),
 						{ tag: "H1", text: "ElasticSearch" }
 					]},
 					{ tag: "DIV", cls: "es-header-menu", children: [
@@ -1358,8 +1358,12 @@
 		},
 
 		_request_handler: function(params) {
+			var url = this.config.base_uri + params.path;
+			if (this.config.proxy) {
+				url = this.config.proxy + '?uri=' + encodeURI(url);
+			}
 			$.ajax(acx.extend({
-				url: this.config.base_uri + params.path,
+				url: url,
 				type: "POST",
 				dataType: "json",
 				error: function(xhr, type, message) {

--- a/proxy.php
+++ b/proxy.php
@@ -1,0 +1,6 @@
+<?php
+
+if (isset($_REQUEST['uri'])) {
+    readfile($_REQUEST['uri']);
+}
+


### PR DESCRIPTION
Allow ES-Head to be used when the ES servers are in a restricted area
for security reasons or network configuration. Edit index.html and
change `proxy: false` to your own proxy. The proxy will be called with
the 'uri' parameter, see proxy.php as an example. Your proxy can also for
example handle authorization. Of course your proxy must have access to
the ES servers.
