### PR TITLE
Added a Show Raw JSON button to query source on Structured Query tab

### DIFF
--- a/lib/es/widgets.js
+++ b/lib/es/widgets.js
@@ -1473,9 +1473,11 @@
 		
 		_searchSource_handler: function(src) {
 			var searchSourceDiv = this.el.find("DIV.es-searchSource");
-			var showRawJSON = $({ tag: "BUTTON", type: "button", text: "Show Raw JSON", id: "showRawJSON", value: JSON.stringify(src), onclick: this._showRawJSON });
 			searchSourceDiv.empty().append(new es.JsonPretty({ obj: src }));
-			searchSourceDiv.append(showRawJSON);
+			if(typeof JSON !== "undefined") {
+				var showRawJSON = $({ tag: "BUTTON", type: "button", text: "Show Raw JSON", id: "showRawJSON", value: JSON.stringify(src), onclick: this._showRawJSON });
+				searchSourceDiv.append(showRawJSON);
+			}
 			searchSourceDiv.show();
 		},
 		


### PR DESCRIPTION
I kept finding myself wanting to copy and paste the JSON displayed when "Show query source" is checked on the Structured Query tab.  However, copying this source from the browser does not yield valid JSON.  Viewing source results in an even worse string.  So, I added a button the displays a valid raw JSON string that can be easily copied.

There are ways to have a button click copy text to a clipboard, but I felt that these methods added ultimately unnecessary dependencies. I feel like what is going on here is a fair compromise between usability and plug-in maintainability.  

Older browsers will not support this.  A check is done to make sure a JSON object exists.  If it does not (OLD browsers), the Show Raw JSON button is not displayed.

Admittedly, this is my first time working with JQuery, so if you think I did something wrong/stupid, I'd greatly appreciate the feedback :-)
