### PR TITLE
append all=true to stats fetch

### DIFF
--- a/lib/es/widgets.js
+++ b/lib/es/widgets.js
@@ -675,7 +675,7 @@
 				this.cluster.get("_cluster/state", this._clusterState_handler);
 				this.cluster.get("_status", this._status_handler);
 				this.cluster.get("_cluster/nodes", this._clusterNodes_handler);
-				this.cluster.get("_cluster/nodes/stats", this._clusterNodeStats_handler);
+				this.cluster.get("_cluster/nodes/stats?all=true", this._clusterNodeStats_handler);
 			} else if(this.status && this.clusterState && this.nodeStats && this.clusterNodes) {
 				var clusterState = this.clusterState;
 				var status = this.status;


### PR DESCRIPTION
By default ES returns a subset of node stats; this ensures that all of the node stats are visible when they are requested.
