### PR TITLE
Increase the width of .clusterOverview-replica and .clusterOverview-null...

### DIFF
--- a/lib/es/es.css
+++ b/lib/es/es.css
@@ -421,7 +421,7 @@ SPAN.jsonPretty-boolean { color: purple; }
 	cursor: pointer;
 	float: left;
 	height: 40px;
-	width: 30px;
+	width: 40px;
 	margin: 4px;
 	border: 2px solid #444;
 	font-size: 32px;


### PR DESCRIPTION
...Replica to be able to accommodate 2-digit labels
