### PR TITLE
Firefox throws a javascript exception when loaded with no repository

### DIFF
--- a/lib/es/widgets.js
+++ b/lib/es/widgets.js
@@ -1363,7 +1363,9 @@
 				type: "POST",
 				dataType: "json",
 				error: function(xhr, type, message) {
-					alert($.parseJSON(xhr.responseText).error);
+					if(xhr.responseText != null) {
+						alert($.parseJSON(xhr.responseText).error);
+					}
 				}
 			}, params));
 		}


### PR DESCRIPTION
When you directly load index.html from the file system we don't seem to get xhr.responseText from the initial query. This error stops the rest of the UI from loading leaving the user with a blank page.
