### PR TITLE
fix storing base_uri in local storage

### DIFF
--- a/lib/es/widgets.js
+++ b/lib/es/widgets.js
@@ -1347,8 +1347,8 @@
 		_status_handler: function(status) {
 			this.el.find(".es-header-menu-item:first").click();
 		},
-		_reconnect_handler: function(base_uri) {
-			localStorage["base_uri"] = base_uri;
+		_reconnect_handler: function() {
+			localStorage["base_uri"] = this.base_uri;
 		}
 	});
 	
@@ -1387,7 +1387,7 @@
 		_node_handler: function(data) {
 			if(data) {
 				this.nameEl.text(data.name);
-				this.fire("reconnect" );
+				this.fire("reconnect", this.base_uri);
 			}
 		},
 		


### PR DESCRIPTION
Good morning,

I noticed that the latest es-head wasn't properly the uri of the ES node in the local storage. This patch fixes it.
