### PR TITLE
Fix issue with structured query with multiple "should" clauses

### DIFF
--- a/lib/es/widgets.js
+++ b/lib/es/widgets.js
@@ -1274,7 +1274,11 @@
 		removeClause: function(uqid) {
 			var ref = this.refmap[uqid],
 				bool = this.search.query.bool[ref.bool];
-			bool.splice(bool.indexOf(ref.clause), 1);
+			var clauseIdx = bool.indexOf(ref.clause);
+			// Check that this clause hasn't already been removed
+			if (clauseIdx >=0) {
+				bool.splice(clauseIdx, 1);
+			}
 		},
 		_setClause: function(value, field, op, bool) {
 			var clause = {}, query = {};


### PR DESCRIPTION
When you add multiple "should" clauses in a structured query, the removeClause() function is called multiple times, since the default clause is itself a "should" clause. On the later calls, indexOf() returns -1, causing whichever "should" clause is last to get spliced out. This PR updates removeClause() to check that the clause-to-remove is present before splicing it out.
