### PR TITLE
Make basic-auth plugin working

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,12 @@
 				var args = location.search.substring(1).split("&").reduce(function(r, p) {
 					r[decodeURIComponent(p.split("=")[0])] = decodeURIComponent(p.split("=")[1]); return r;
 				}, {});
-				new es.ElasticSearchHead("body", { id: "es", base_uri: args["base_uri"] || base_uri });
+				new es.ElasticSearchHead("body", 
+                                {   id: "es", 
+                                    base_uri: args["base_uri"] || base_uri,
+                                    login : args["auth_login"] || "",
+                                    password : args["auth_password"]
+                                });
 			});
 		</script>
 		<link rel="icon" href="lib/es/images/favicon.png" type="image/png">

--- a/lib/es/widgets.js
+++ b/lib/es/widgets.js
@@ -1352,6 +1352,16 @@
 				// XHR request fails if the URL is not ending with a "/"
 				this.base_uri += "/";
 			}
+                        
+                        if(this.config.login && this.config.login.length > 0) {
+                            var userAndPw = this.config.login + ":" + this.config.password;
+                            var credentials = window.btoa(userAndPw);
+                            $.ajaxSetup({
+                                headers: {
+                                    'Authorization': "Basic " + credentials
+                                }
+                            });                               
+                        }
 			this.cluster = new es.Cluster({ base_uri: this.base_uri });
 			this._initElements(parent);
 			this.instances = {};


### PR DESCRIPTION
There is a basic authentication plugin and my [modification](https://github.com/karussell/elasticsearch-http-basic) makes it possible to be used from an ajax query (enables OPTIONS queries).

Now we need basic authentication for elasticsearch-head in order to work around the limitation of adding custom header parameters to the elasticsearch response (which could be used to challenge the browser to let the user enter the password). This is also the reason why accessing elasticsearch-head via localhost:9200/_plugins/head/ will not work.

Instead you install head locally and add "auth_user=yourlogin&auth_password=yourpassword" to the URL of elasticsearch-head. The elasticsearch configuration should look like:

> http.basic.user: yourlogin
> http.basic.password: yourpassword
> http.cors.allow-headers: "X-Requested-With, Content-Type, Content-Length, Authorization"
