### PR TITLE
null check fixes rendering error for Browser tab after sending JSON arrays to ES

### DIFF
--- a/lib/es/core.js
+++ b/lib/es/core.js
@@ -129,7 +129,9 @@
 				var field = paths[dpath] = fields[field_name] = fields[field_name] || acx.extend({
 					field_name: field_name, core_type: coretype_map[mapping.type], dpaths: []
 				}, default_property_map[coretype_map[mapping.type]], mapping);
-				field.dpaths.push(dpath);
+				if (fields.dpaths) {
+				  field.dpaths.push(dpath);
+				}
 				return field;
 			}
 			function getFields(properties, type, index, listeners) {


### PR DESCRIPTION
Quick fix for an issue I was having in Firefox. I didn't delve too much into the root cause of the problem, but this definitely fixed it for me. Submitting larger JSON objects to ES, incuding array objects, throws an error here and prevents the Browser tab from rendering.
