### PR TITLE
Better autodetection of ElasticSearch endpoint URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
 		<script>
 			$(function() {
 				if(location.href.contains("/_plugin/")) {
-					var base_uri = location.protocol + "//" + location.host + "/";
+					var base_uri = location.href.replace(/_plugin\/.*/, '');
 				}
 				var args = location.search.substring(1).split("&").reduce(function(r, p) {
 					r[decodeURIComponent(p.split("=")[0])] = decodeURIComponent(p.split("=")[1]); return r;


### PR DESCRIPTION
Instead of assuming that ElasticSearch endpoint is mounted at root URL of the
host, use the parent location of _plugin/head.

http://host:12345/mounted/here/_plugin/head will look at
http://host:12345/mounted/here/ instead of http://host:12345/
