### PR TITLE
Fixing nodes stats for elasticsearch 1.0 RC

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -3032,8 +3032,8 @@
 				this.clusterNodes = null;
 				this.cluster.get("_cluster/state", this._clusterState_handler);
 				this.cluster.get("_status", this._status_handler);
-				this.cluster.get("_cluster/nodes", this._clusterNodes_handler);
-				this.cluster.get("_cluster/nodes/stats?all=true", this._clusterNodeStats_handler);
+				this.cluster.get("_nodes", this._clusterNodes_handler);
+				this.cluster.get("_nodes/stats?all=true", this._clusterNodeStats_handler);
 			} else if(this.status && this.clusterState && this.nodeStats && this.clusterNodes) {
 				var clusterState = this.clusterState;
 				var status = this.status;

--- a/src/app/ui/clusterOverview/clusterOverview.js
+++ b/src/app/ui/clusterOverview/clusterOverview.js
@@ -109,8 +109,8 @@
 				this.clusterNodes = null;
 				this.cluster.get("_cluster/state", this._clusterState_handler);
 				this.cluster.get("_status", this._status_handler);
-				this.cluster.get("_cluster/nodes", this._clusterNodes_handler);
-				this.cluster.get("_cluster/nodes/stats?all=true", this._clusterNodeStats_handler);
+				this.cluster.get("_nodes", this._clusterNodes_handler);
+				this.cluster.get("_nodes/stats?all=true", this._clusterNodeStats_handler);
 			} else if(this.status && this.clusterState && this.nodeStats && this.clusterNodes) {
 				var clusterState = this.clusterState;
 				var status = this.status;


### PR DESCRIPTION
Elasticsearch 1.0 will have some monitoring URLs removed and changed.

This commit ensures that the nodes info and nodes stats will be fetched with 0.90 and 1.0.

The all parameter is not needed for 1.0 anymore, as everything is returned by default (but needed for 0.90).
