### PR TITLE
Adding sorting of index names in the index selector

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -3719,7 +3719,11 @@
 		
 		_update_handler: function(data) {
 			var options = [];
-			for(var name in data.indices) { options.push(this._option_template(name, data.indices[name])); }
+			var index_names = Object.keys(data.indices).sort();
+			for(var i=0; i < index_names.length; i++) { 
+				name = index_names[i];
+				options.push(this._option_template(name, data.indices[name])); 
+			}
 			this.el.find(".uiIndexSelector-select").empty().append(this._select_template(options));
 			this._indexChanged_handler();
 		},

--- a/src/app/ui/indexSelector/indexSelector.js
+++ b/src/app/ui/indexSelector/indexSelector.js
@@ -16,7 +16,11 @@
 		
 		_update_handler: function(data) {
 			var options = [];
-			for(var name in data.indices) { options.push(this._option_template(name, data.indices[name])); }
+			var index_names = Object.keys(data.indices).sort();
+			for(var i=0; i < index_names.length; i++) { 
+				name = index_names[i];
+				options.push(this._option_template(name, data.indices[name])); 
+			}
 			this.el.find(".uiIndexSelector-select").empty().append(this._select_template(options));
 			this._indexChanged_handler();
 		},


### PR DESCRIPTION
My JavaScript skills are pretty weak, but this works. It's really useful to have sorted index names when you have lots of indices.
