### PR TITLE
Closes #109 - Set content type to "application/json" for compatability with the elasticsearch-transport-wares

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -1241,10 +1241,20 @@
 			return $.ajax( $.extend({
 				url: this.base_uri + params.path,
 				dataType: "json",
+				contentType: "application/json",
 				error: function(xhr, type, message) {
+					//we had an error, it could be that we're talking to an old version of elasticsearch that doesn't support cross origin requests with a contentType set, so try again without it.
 					if("console" in window) {
-						console.log({ "XHR Error": type, "message": message });
+						console.log({ "XHR Error": type, "message": message, "retrying": true });
 					}
+					var repeatRequestParams = this;
+					delete repeatRequestParams['contentType'];
+					repeatRequestParams['error'] = function(xhr, type, message) {
+						if("console" in window) {
+							console.log({ "XHR Error": type, "message": message, "retrying": false });
+						}
+					}
+					$.ajax(repeatRequestParams);
 				}
 			},  params) );
 		},

--- a/src/app/services/cluster.js
+++ b/src/app/services/cluster.js
@@ -14,10 +14,20 @@
 			return $.ajax( $.extend({
 				url: this.base_uri + params.path,
 				dataType: "json",
+				contentType: "application/json",
 				error: function(xhr, type, message) {
+					//we had an error, it could be that we're talking to an old version of elasticsearch that doesn't support cross origin requests with a contentType set, so try again without it.
 					if("console" in window) {
-						console.log({ "XHR Error": type, "message": message });
+						console.log({ "XHR Error": type, "message": message, "retrying": true });
 					}
+					var repeatRequestParams = this;
+					delete repeatRequestParams['contentType'];
+					repeatRequestParams['error'] = function(xhr, type, message) {
+						if("console" in window) {
+							console.log({ "XHR Error": type, "message": message, "retrying": false });
+						}
+					}
+					$.ajax(repeatRequestParams);
 				}
 			},  params) );
 		},


### PR DESCRIPTION
If an error is detected, it will retry the request with the content type not set (because elasticsearch prior to 0.20.0 didn't set the correct CORS headers, the browser would block this request if Head was connecting to a host different to the one which it is on).
