### PR TITLE
Display plugin information

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -4059,7 +4059,7 @@
 				{ text: i18n.text("Nav.Status"), path: "_status" },
 				{ text: i18n.text("Nav.NodeStats"), path: "_cluster/nodes/stats" },
 				{ text: i18n.text("Nav.ClusterNodes"), path: "_cluster/nodes" },
-				{ text: i18n.text("Nav.Plugins"), path: "_nodes/plugin" },
+				{ text: i18n.text("Nav.Plugins"), path: "_nodes/plugins" },
 				{ text: i18n.text("Nav.ClusterState"), path: "_cluster/state" },
 				{ text: i18n.text("Nav.ClusterHealth"), path: "_cluster/health" },
 				{ text: i18n.text("Nav.Templates"), path: "_template" }

--- a/src/app/ui/header/header.js
+++ b/src/app/ui/header/header.js
@@ -17,7 +17,7 @@
 				{ text: i18n.text("Nav.Status"), path: "_status" },
 				{ text: i18n.text("Nav.NodeStats"), path: "_cluster/nodes/stats" },
 				{ text: i18n.text("Nav.ClusterNodes"), path: "_cluster/nodes" },
-				{ text: i18n.text("Nav.Plugins"), path: "_nodes/plugin" },
+				{ text: i18n.text("Nav.Plugins"), path: "_nodes/plugins" },
 				{ text: i18n.text("Nav.ClusterState"), path: "_cluster/state" },
 				{ text: i18n.text("Nav.ClusterHealth"), path: "_cluster/health" },
 				{ text: i18n.text("Nav.Templates"), path: "_template" }


### PR DESCRIPTION
The correct path for plugin info is _nodes/plugins, not _nodes/plugin.
Could you please check this PR?
