### PR TITLE
Use '_cluster/health' endpoint to compute ES cluster colour (#147)

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -1303,13 +1303,14 @@
 			this.clusterNodes = null;
 		},
 		refresh: function() {
-			var self = this, clusterState, status, nodeStats, clusterNodes; 
+			var self = this, clusterState, status, nodeStats, clusterNodes, clusterHealth;
 			function updateModel() {
-				if( clusterState && status && nodeStats && clusterNodes ) {
+				if( clusterState && status && nodeStats && clusterNodes && clusterHealth ) {
 					this.clusterState = clusterState;
 					this.status = status;
 					this.nodeStats = nodeStats;
 					this.clusterNodes = clusterNodes;
+					this.clusterHealth = clusterHealth;
 					this.fire( "data", this );
 				}
 			}
@@ -1329,6 +1330,10 @@
 				clusterNodes = data;
 				updateModel.call( self );
 			});
+			this.cluster.get("_cluster/health", function( data ) {
+				clusterHealth = data;
+				updateModel.call( self );
+			});
 		},
 		_clusterState_handler: function(state) {
 			this.clusterState = state;
@@ -1345,6 +1350,10 @@
 		_clusterNodes_handler: function(nodes) {
 			this.clusterNodes = nodes;
 			this.redraw("clusterNodes");
+		},
+		_clusterHealth_handler: function(health) {
+			this.clusterHealth = health;
+			this.redraw("status");
 		}
 	});
 
@@ -4089,7 +4098,7 @@
 			this._clusterState = this.config.clusterState;
 			this._clusterState.on("data", function( state ) {
 				var shards = state.status._shards;
-				var colour = shards.failed > 0 ? "red" : ( shards.total > shards.successful ? "yellow" : "green" );
+				var colour = state.clusterHealth.status;
 				var name = state.clusterState.cluster_name;
 				this.nameEl.text( name );
 				this.statEl

--- a/src/app/services/clusterState/clusterState.js
+++ b/src/app/services/clusterState/clusterState.js
@@ -16,13 +16,14 @@
 			this.clusterNodes = null;
 		},
 		refresh: function() {
-			var self = this, clusterState, status, nodeStats, clusterNodes; 
+			var self = this, clusterState, status, nodeStats, clusterNodes, clusterHealth;
 			function updateModel() {
-				if( clusterState && status && nodeStats && clusterNodes ) {
+				if( clusterState && status && nodeStats && clusterNodes && clusterHealth ) {
 					this.clusterState = clusterState;
 					this.status = status;
 					this.nodeStats = nodeStats;
 					this.clusterNodes = clusterNodes;
+					this.clusterHealth = clusterHealth;
 					this.fire( "data", this );
 				}
 			}
@@ -42,6 +43,10 @@
 				clusterNodes = data;
 				updateModel.call( self );
 			});
+			this.cluster.get("_cluster/health", function( data ) {
+				clusterHealth = data;
+				updateModel.call( self );
+			});
 		},
 		_clusterState_handler: function(state) {
 			this.clusterState = state;
@@ -58,6 +63,10 @@
 		_clusterNodes_handler: function(nodes) {
 			this.clusterNodes = nodes;
 			this.redraw("clusterNodes");
+		},
+		_clusterHealth_handler: function(health) {
+			this.clusterHealth = health;
+			this.redraw("status");
 		}
 	});
 

--- a/src/app/ui/header/header.js
+++ b/src/app/ui/header/header.js
@@ -47,7 +47,7 @@
 			this._clusterState = this.config.clusterState;
 			this._clusterState.on("data", function( state ) {
 				var shards = state.status._shards;
-				var colour = shards.failed > 0 ? "red" : ( shards.total > shards.successful ? "yellow" : "green" );
+				var colour = state.clusterHealth.status;
 				var name = state.clusterState.cluster_name;
 				this.nameEl.text( name );
 				this.statEl


### PR DESCRIPTION
The idea behind this pull request is to use the `_cluster/health` endpoint so that the plugin reflects the colour of the cluster computed on the ES side, instead of deducing it from the shards count. As said in #147 shards can be initializing or relocating which makes the plugin not display the "correct" colour.

On the implementation side I'm not very familiar with JS development so I mostly adapted/completed existing sections. The plugin works for me on my local machine as is, but of course your critic eye on this is very welcome. Also note that I didn't know how to run the tests nor to add some tests here, let me know if I can complete this PR with some tests, I'd be more than happy to do that with some guidance.

Anyway, thank you very much for an awesome plugin, I couldn't do my job without it !!!

PS: I had troubles building the plugin at first, I had to install a bunch of packages that didn't install through `npm install`, actually: `npm install gaze cookie-signature grunt-lib-phantomjs tiny-lr bytes chalk debug lodash send rimraf` ; let me know if I need to open an other issue or PR for this.