### PR TITLE
Listen on all interfaces by default, grunt-cli dep

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -81,6 +81,9 @@ module.exports = function(grunt) {
 		connect: {
 			server: {
 				options: {
+                    // listen on all interfaces by default
+                    // remove the "hostname" key to default to localhost:<port>
+					hostname: null,
 					port: 9100,
 					base: '.',
 					keepalive: true

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
     "grunt-contrib-jasmine": "0.6.4",
     "karma": "0.12.16",
     "grunt-karma": "0.8.3"
+  },
+  "dependencies": {
+    "grunt-cli": "^0.1.13"
   }
 }


### PR DESCRIPTION
* listen on all interfaces (0.0.0.0) by default
* add helpful remark on how to enable that (saves hunting around to figure out how)
* include grunt-cli in package.json for the grunt binary