### PR TITLE
Update app.js for better IE11+ compatibility

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -2168,7 +2168,12 @@
 				return (value && (/array|object/i).test(value.constructor.name)) ? "expando" : "";
 			},
 			"parse": function (member) {
-				return this[(member == null) ? 'null' : member.constructor.name.toLowerCase()](member);
+				// handle IE's lack of an objects 'name' attribute
+				if ( member != null ) {
+					return this[(member.constructor.name == undefined) ? typeof(member) : member.constructor.name.toLowerCase()](member);
+				} else {
+					return this['null'](member);
+				}
 			},
 			"null": function (value) {
 				return this['value']('null', 'null');


### PR DESCRIPTION
IE doesn't have a name attribute for objects in javascript - this patch provides for this, allowing JSON panels to display in IE.