### PR TITLE
Fix the plugin install command

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -10,7 +10,7 @@ There are two main ways of running and installing elasticsearch-head
 
 h4. Running as a plugin of Elasticsearch
 
-* @sudo elasticsearch/bin/plugin -install mobz/elasticsearch-head@
+* @sudo elasticsearch/bin/plugin install mobz/elasticsearch-head@
 * @open http://localhost:9200/_plugin/head/@
 
 This will automatically download the latest version of elasticsearch-head from github and run it as a plugin within the elasticsearch cluster. In this mode;


### PR DESCRIPTION
fixing 
./bin/plugin -install mobz/elasticsearch-head
ERROR: unknown command [-install]. Use [-h] option to list available commands

The  "-" does not work