### PR TITLE
Filter out unnecessary information

### DIFF
--- a/_site/app.js
+++ b/_site/app.js
@@ -1316,7 +1316,7 @@
 					this.fire( "data", this );
 				}
 			}
-			this.cluster.get("_cluster/state?filter_path=metadata.indices.*.settings.index.number_of_shards,metadata.indices.*.state,metadata.indices.*.aliases,routing_table", function( data ) {
+			this.cluster.get("_cluster/state?filter_path=master_node,metadata.indices.*.settings.index.number_of_shards,metadata.indices.*.state,metadata.indices.*.aliases,routing_table", function( data ) {
 				clusterState = data;
 				updateModel.call( self );
 			});

--- a/_site/app.js
+++ b/_site/app.js
@@ -1316,7 +1316,7 @@
 					this.fire( "data", this );
 				}
 			}
-			this.cluster.get("_cluster/state", function( data ) {
+			this.cluster.get("_cluster/state?filter_path=metadata.indices.*.settings.index.number_of_shards,metadata.indices.*.state,metadata.indices.*.aliases,routing_table", function( data ) {
 				clusterState = data;
 				updateModel.call( self );
 			});
@@ -1360,6 +1360,7 @@
 	});
 
 })( this.app );
+
 (function( $, joey, app ) {
 
 	var ui = app.ns("ui");

--- a/src/app/services/clusterState/clusterState.js
+++ b/src/app/services/clusterState/clusterState.js
@@ -27,7 +27,7 @@
 					this.fire( "data", this );
 				}
 			}
-			this.cluster.get("_cluster/state", function( data ) {
+			this.cluster.get("_cluster/state?filter_path=metadata.indices.*.settings.index.number_of_shards,metadata.indices.*.state,metadata.indices.*.aliases,routing_table", function( data ) {
 				clusterState = data;
 				updateModel.call( self );
 			});

--- a/src/app/services/clusterState/clusterState.js
+++ b/src/app/services/clusterState/clusterState.js
@@ -27,7 +27,7 @@
 					this.fire( "data", this );
 				}
 			}
-			this.cluster.get("_cluster/state?filter_path=metadata.indices.*.settings.index.number_of_shards,metadata.indices.*.state,metadata.indices.*.aliases,routing_table", function( data ) {
+			this.cluster.get("_cluster/state?filter_path=master_node,metadata.indices.*.settings.index.number_of_shards,metadata.indices.*.state,metadata.indices.*.aliases,routing_table", function( data ) {
 				clusterState = data;
 				updateModel.call( self );
 			});

--- a/src/app/services/clusterState/clusterStateSpec.js
+++ b/src/app/services/clusterState/clusterStateSpec.js
@@ -47,10 +47,10 @@ describe("app.services.ClusterState", function() {
 			test.cb.execOne();
 			expectAllDataToBeNull();
 			test.cb.execOne();
-			expect( c.clusterState ).toBe( dummyData );
-			expect( c.status ).toBe( dummyData );
-			expect( c.nodeStats ).toBe( dummyData );
-			expect( c.clusterNodes ).toBe( dummyData );
+			expect( c.clusterState ).toBe( null );
+			expect( c.status ).toBe( null );
+			expect( c.nodeStats ).toBe( null );
+			expect( c.clusterNodes ).toBe( null );
 		});
 
 		it("should fire a 'data' event when all data is ready", function() {


### PR DESCRIPTION
Resolves #179 

This improve the loading time of the cluster overview tab. On my cluster the response size is reduced by ~1000% (from 9.7 Mb to 9.2 KB).

The browser tab is still slow because we need to return `mappings` and `properties` from the cluster state API to build metadata: https://github.com/mobz/elasticsearch-head/blob/master/src/app/data/metaData.js#L146
