### PR TITLE
Add Dockerfile V2

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node
+MAINTAINER Niko Bellic <niko.bellic@kakaocorp.com>
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+RUN npm install -g grunt
+
+COPY package.json /usr/src/app/package.json
+RUN npm install
+
+COPY . /usr/src/app
+
+EXPOSE 9100
+
+CMD grunt server


### PR DESCRIPTION
related to #80 

changes
* uses node as docker base image
* uses elasticsearch-head version so that we don't have to hard code supported ES version
  * tag mobz/elasticsearch-head:1.x, mobz/elasticsearch-head:2.x, mobz/elasticsearch-head:5.x so on.
