### PR TITLE
AWS Elasticsearch /_cluster/state support

### DIFF
--- a/_site/app.js
+++ b/_site/app.js
@@ -3562,7 +3562,9 @@
 				node.data_node = !( cluster && cluster.attributes && cluster.attributes.data === "false" );
 				for(var i = 0; i < indices.length; i++) {
 					node.routings[i] = node.routings[i] || { name: indices[i].name, replicas: [] };
-					node.routings[i].max_number_of_shards = indices[i].metadata.settings["index.number_of_shards"];
+					if (indices[i].metadata.settings) {
+						node.routings[i].max_number_of_shards = indices[i].metadata.settings["index.number_of_shards"];
+					}
 					node.routings[i].open = indices[i].state === "open";
 				}
 			});

--- a/src/app/ui/clusterOverview/clusterOverview.js
+++ b/src/app/ui/clusterOverview/clusterOverview.js
@@ -239,7 +239,9 @@
 				node.data_node = !( cluster && cluster.attributes && cluster.attributes.data === "false" );
 				for(var i = 0; i < indices.length; i++) {
 					node.routings[i] = node.routings[i] || { name: indices[i].name, replicas: [] };
-					node.routings[i].max_number_of_shards = indices[i].metadata.settings["index.number_of_shards"];
+					if (indices[i].metadata.settings) {
+						node.routings[i].max_number_of_shards = indices[i].metadata.settings["index.number_of_shards"];
+					}
 					node.routings[i].open = indices[i].state === "open";
 				}
 			});


### PR DESCRIPTION
# Overview
Fixes part of the overall issue with making elasticsearch-head work against AWS Elasticsearch (as reported in #273).

I discovered that while AWS Elasticsearch now supports the `/_cluster/state` endpoint, one thing it does **not** do is return an object at the path `indices.metadata.settings`, which caused elasticsearch-head to fail as it assumes the object exists.  I modified it so that it now checks for the object's existence before reading out any settings.  This appears to work just fine as ultimately it gets the shard count elsewhere.

# Known issues
None

# Notes
* The second commit states `_site/app.js` was modified by hand, but the commit is now identical to what is emitted by Grunt, so disregard.  (There was previously a discrepancy due to stray CRs in the file at one point, which is why the distinction was made.)

Thanks,
\# Chris