### PR TITLE
Don't send JSON in the querystring of GET requests

### DIFF
--- a/_site/app.js
+++ b/_site/app.js
@@ -2889,6 +2889,7 @@
 					.children().find(":last-child").each(function(i, j) { j.scrollIntoView(false); }).end()
 					.scrollLeft(0);
 			}
+			if (type === 'GET') { query = null; }
 			this.config.cluster.request({
 				url: base_uri + path,
 				type: type,

--- a/src/app/ui/anyRequest/anyRequest.js
+++ b/src/app/ui/anyRequest/anyRequest.js
@@ -79,6 +79,7 @@
 					.children().find(":last-child").each(function(i, j) { j.scrollIntoView(false); }).end()
 					.scrollLeft(0);
 			}
+			if (type === 'GET') { query = null; }
 			this.config.cluster.request({
 				url: base_uri + path,
 				type: type,


### PR DESCRIPTION
This prevents appending `?{}` or other JSON to the querystring of GET requests. It looks like earlier versions of elasticsearch didn't complain when you did something like `localhost:9200/_snapshot/_all?{}` but the 5.x version we're using now doesn't like it.