### PR TITLE
Add npm run scripts "start"

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -13,7 +13,7 @@ h4. Running with built in server
 * @git clone git://github.com/mobz/elasticsearch-head.git@
 * @cd elasticsearch-head@
 * @npm install@
-* @grunt server@
+* @npm run start@
 
 * @open@ "http://localhost:9100/":http://localhost:9100/
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "test"
   },
   "scripts": {
+    "start": "grunt server",
     "test": "grunt jasmine",
     "proxy": "node proxy/index.js"
   },


### PR DESCRIPTION
# Why

- `npm run start` (or `yarn start`) is more declarative representation for running server in Node.js development
- and it encapsulates grunt-implementation from public interface
- Furthermore, npm solves dependencies when running npm scripts, so you do not need to have `grunt` globally installed

# NOTE

You can still run start a grunt server with running `grunt server` if `grunt` is globally installed, or `$(npm bin)/grunt start`.