### PR TITLE
Wrap Node.js server with tini

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM node
 MAINTAINER Niko Bellic <niko.bellic@kakaocorp.com>
 
+# wrap Node.js process with tini to handle stop signal
+ENV TINI_VERSION v0.16.1
+RUN wget -O /tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini \
+    && chmod +x /tini
+
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
@@ -13,4 +18,5 @@ COPY . /usr/src/app
 
 EXPOSE 9100
 
-CMD grunt server
+ENTRYPOINT ["/tini", "--"]
+CMD ["grunt", "server"]

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,8 +1,15 @@
 # docker build -t mobz/elasticsearch-head:5-alpine -f Dockerfile-alpine .
 
 FROM node:alpine
+
+# wrap Node.js process with tini to handle stop signal
+RUN apk add --no-cache --update tini
+
 WORKDIR /usr/src/app
 RUN npm install http-server
 COPY . .
+
 EXPOSE 9100
-CMD node_modules/http-server/bin/http-server _site -p 9100
+
+ENTRYPOINT ["tini", "--"]
+CMD ["node_modules/http-server/bin/http-server", "_site", "-p", "9100"]


### PR DESCRIPTION
We cannot stop elasticsearch-head Docker container gracefully, because Node.js in Docker container cannot handle kernel signal (`SIGINT`, `SIGTERM` and so on).
https://github.com/nodejs/docker-node/blob/078ff84cb756df33fe3444090914e65a0721c9fd/docs/BestPractices.md#handling-kernel-signals

To handle these signals, we have to wrap Node.js process with lightweight init system, for example [tini](https://github.com/krallin/tini), or use `docker run --init` flag.
However, Kubernetes does not support this flag.

I added some steps to install tini in elasticsearch-head Docker image. All Docker users will be able to stop gracefully by this change.