### PR TITLE
Always show Refresh button on Overview tab

### DIFF
--- a/_site/app.js
+++ b/_site/app.js
@@ -3642,7 +3642,7 @@
 						this._refreshButton
 					]
 				}),
-				{ tag: "DIV", cls: "uiClusterOverview-table" }
+				{ tag: "DIV", cls: "uiClusterOverview-table", css: { overflow: "auto" } }
 			] };
 		}
 	});


### PR DESCRIPTION
Toolbar has fixed width. So in situation when I have a lot of indices I can't see "Refresh" button and it is difficult check the status of indices from the left.
See example:
<img width="1438" alt="screen shot 2018-01-30 at 17 18 51" src="https://user-images.githubusercontent.com/1928972/35615674-26dff794-0673-11e8-8722-41109d7f6d19.png">

With this fix toolbar is always shown