### PR TITLE
Fix proxy usage of Access-Control-Allow-Methods header.

### DIFF
--- a/proxy/index.js
+++ b/proxy/index.js
@@ -2,7 +2,7 @@ const http = require("http");
 
 const CORS_SETTINGS = {
 	origin: "http://localhost:9100",
-	methods: "GET PUT POST DELETE OPTIONS HEAD",
+	methods: "GET, PUT, POST, DELETE, OPTIONS, HEAD",
 	headers: "Authorization, Content-Type"
 }
 


### PR DESCRIPTION
HTTP request method list should be comma-delimited (see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods)

UI actions that used anything other than GET did not work in latest versions of Chrome and Firefox when using the local proxy.