### PR TITLE
Fix the search query when the bool query is type missing

### DIFF
--- a/_site/app.js
+++ b/_site/app.js
@@ -1217,7 +1217,11 @@
 				query["query"] = value;
 			} else if(op === "missing") {
 				op = "exists";
-				bool = "must_not";
+				if (bool === "must_not") {
+					bool = "must"
+				} else if (bool === "must") {
+					bool = "must_not"
+				}
 				query["field"] = field.substring(field.indexOf(".")+1);
 			} else {
 				query[field.substring(field.indexOf(".")+1)] = value;

--- a/src/app/data/boolQuery.js
+++ b/src/app/data/boolQuery.js
@@ -56,7 +56,11 @@
 				query["query"] = value;
 			} else if(op === "missing") {
 				op = "exists";
-				bool = "must_not";
+				if (bool === "must_not") {
+					bool = "must"
+				} else if (bool === "must") {
+					bool = "must_not"
+				}
 				query["field"] = field.substring(field.indexOf(".")+1);
 			} else {
 				query[field.substring(field.indexOf(".")+1)] = value;


### PR DESCRIPTION
Currently, no matter what is the bool queries (must/must not/should) when using operation missing, the query is always generated with operation exists in the must not querry:

![image](https://user-images.githubusercontent.com/10993669/94941911-c8627780-04ff-11eb-897d-10b6217f3e77.png)

This PR fixes that