### PR TITLE
Fix Index Test Analyzer feature for ES versions after 5.x

### DIFF
--- a/_site/app.js
+++ b/_site/app.js
@@ -3151,9 +3151,19 @@
                         }).open();
 		},
 		_testAnalyser_handler: function(index) {
-			this.cluster.get(encodeURIComponent( index.name ) + "/_analyze?text=" + encodeURIComponent( prompt( i18n.text("IndexCommand.TextToAnalyze") ) ), function(r) {
-				alert(JSON.stringify(r, true, "  "));
-			});
+			if(this.cluster._version_parts[0] <= 5) {
+				this.cluster.get(encodeURIComponent( index.name ) + "/_analyze?text=" + encodeURIComponent( prompt( i18n.text("IndexCommand.TextToAnalyze") ) ), function(r) {
+					new ui.JsonPanel({ json: r, title: "" });
+				}); 
+			} else {
+				var command = {
+					"analyzer" : prompt( i18n.text("IndexCommand.AnalyzerToUse") ),
+					"text": prompt( i18n.text("IndexCommand.TextToAnalyze") )
+				};
+				this.cluster.post(encodeURIComponent(index.name) + "/_analyze", JSON.stringify(command), function(r) {
+					new ui.JsonPanel({ json: r, title: "" });
+				});
+			}		
 		},
 		_deleteIndexAction_handler: function(index) {
 			if( prompt( i18n.text("AliasForm.DeleteAliasMessage", i18n.text("Command.DELETE"), index.name ) ) === i18n.text("Command.DELETE") ) {

--- a/_site/lang/en_strings.js
+++ b/_site/lang/en_strings.js
@@ -51,6 +51,7 @@ i18n.setKeys({
 	"IndexInfoMenu.Status": "Index Status",
 	"IndexInfoMenu.Metadata": "Index Metadata",
 	"IndexCommand.TextToAnalyze": "Text to Analyse",
+	"IndexCommand.AnalyzerToUse": "Name of Analyzer (built-in or customized)",
 	"IndexCommand.ShutdownMessage": "type ''{0}'' to shutdown {1}. Node can NOT be restarted from this interface",
 	"IndexOverview.PageTitle": "Indices Overview",
 	"IndexSelector.NameWithDocs": "{0} ({1} docs)",

--- a/src/app/lang/en_strings.js
+++ b/src/app/lang/en_strings.js
@@ -51,6 +51,7 @@ i18n.setKeys({
 	"IndexInfoMenu.Status": "Index Status",
 	"IndexInfoMenu.Metadata": "Index Metadata",
 	"IndexCommand.TextToAnalyze": "Text to Analyse",
+	"IndexCommand.AnalyzerToUse": "Name of Analyzer (built-in or customized)",
 	"IndexCommand.ShutdownMessage": "type ''{0}'' to shutdown {1}. Node can NOT be restarted from this interface",
 	"IndexOverview.PageTitle": "Indices Overview",
 	"IndexSelector.NameWithDocs": "{0} ({1} docs)",

--- a/src/app/ui/nodesView/nodesView.js
+++ b/src/app/ui/nodesView/nodesView.js
@@ -101,9 +101,19 @@
                         }).open();
 		},
 		_testAnalyser_handler: function(index) {
-			this.cluster.get(encodeURIComponent( index.name ) + "/_analyze?text=" + encodeURIComponent( prompt( i18n.text("IndexCommand.TextToAnalyze") ) ), function(r) {
-				alert(JSON.stringify(r, true, "  "));
-			});
+			if(this.cluster._version_parts[0] <= 5) {
+				this.cluster.get(encodeURIComponent( index.name ) + "/_analyze?text=" + encodeURIComponent( prompt( i18n.text("IndexCommand.TextToAnalyze") ) ), function(r) {
+					new ui.JsonPanel({ json: r, title: "" });
+				}); 
+			} else {
+				var command = {
+					"analyzer" : prompt( i18n.text("IndexCommand.AnalyzerToUse") ),
+					"text": prompt( i18n.text("IndexCommand.TextToAnalyze") )
+				};
+				this.cluster.post(encodeURIComponent(index.name) + "/_analyze", JSON.stringify(command), function(r) {
+					new ui.JsonPanel({ json: r, title: "" });
+				});
+			}		
 		},
 		_deleteIndexAction_handler: function(index) {
 			if( prompt( i18n.text("AliasForm.DeleteAliasMessage", i18n.text("Command.DELETE"), index.name ) ) === i18n.text("Command.DELETE") ) {


### PR DESCRIPTION
The Test Analyzer is not working for ES versions after 5.x since analyzer API does not support request parameters anymore.
This PR will check the version first and then calling analyzer API to get analyzed text. In addition, `alert` might omit the json if it is too long so `JsonPanel` is used to show all json content of analyzed text.

![image](https://user-images.githubusercontent.com/10993669/96369003-913bc980-1181-11eb-9bc0-71b82dac8a89.png)
